### PR TITLE
Implement base init service and tests

### DIFF
--- a/__tests__/init-service.test.ts
+++ b/__tests__/init-service.test.ts
@@ -1,0 +1,47 @@
+import { InitProjectService } from "@/services/init_service/initProjectService";
+import { ProjectBuilder } from "@/services/init_service/projectBuilder";
+import { databaseService } from "@/services/database_service/databaseService";
+import { dbMock } from "./dbMock";
+
+jest.mock("@/services/database_service/databaseService", () => ({
+    databaseService: {
+        createProject: jest.fn(),
+        createProfile: jest.fn(),
+    },
+}));
+
+describe('InitProjectService', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should create project and profile from builder data', async () => {
+        const createProjectMock = databaseService.createProject as jest.Mock;
+        const createProfileMock = databaseService.createProfile as jest.Mock;
+
+        createProjectMock.mockResolvedValue({ id: dbMock.project.id });
+        createProfileMock.mockResolvedValue({ id: dbMock.profile.id });
+
+        const builder = new ProjectBuilder({
+            userId: dbMock.user.id,
+            title: dbMock.project.title,
+            description: dbMock.project.description,
+        }).setBiometrics(dbMock.profile.biometrics);
+
+        const service = new InitProjectService();
+        const result = await service.initialize(builder);
+
+        expect(createProjectMock).toHaveBeenCalledWith(
+            dbMock.user.id,
+            dbMock.project.title,
+            dbMock.project.description
+        );
+        expect(createProfileMock).toHaveBeenCalledWith(
+            dbMock.project.id,
+            dbMock.profile.biometrics,
+            {}
+        );
+        expect(result).toEqual({ projectId: dbMock.project.id, profileId: dbMock.profile.id });
+    });
+});
+

--- a/services/init_service/initProjectService.ts
+++ b/services/init_service/initProjectService.ts
@@ -1,4 +1,56 @@
+import { databaseService } from "@/services/database_service/databaseService";
+import { ProjectBuilder } from "./projectBuilder";
+import { InitResult } from "./projectInitTypes";
 
+/**
+ * InitProjectService orchestrates project creation using data from ProjectBuilder.
+ * AI related logic is left as placeholders for future implementation.
+ */
 export class InitProjectService {
+    constructor(private db = databaseService) {}
 
+    /**
+     * Execute initialization sequence: create project, profile and initial plan.
+     */
+    async initialize(builder: ProjectBuilder): Promise<InitResult> {
+        const data = builder.build();
+
+        // 1. basic project entry
+        const project = await this.db.createProject(
+            data.userId,
+            data.title,
+            data.description
+        );
+
+        // 2. create user profile if biometrics provided
+        let profile;
+        if (data.biometrics) {
+            // target biometrics generation via AI is not defined yet
+            profile = await this.db.createProfile(project.id, data.biometrics, {});
+        }
+
+        // 3. select template and generate plan config via AI (not implemented)
+        if (!data.template) {
+            await this.selectTemplate();
+        }
+        await this.generateWorkoutPlan();
+
+        return { projectId: project.id, profileId: profile?.id };
+    }
+
+    /**
+     * Placeholder: choose suitable ConfigTemplate using AI module.
+     */
+    private async selectTemplate(): Promise<void> {
+        // TODO: integrate AI selection logic
+        return Promise.resolve();
+    }
+
+    /**
+     * Placeholder: generate WorkoutPlanConfig and execute ConfigExecutor.
+     */
+    private async generateWorkoutPlan(): Promise<void> {
+        // TODO: call AI module and ConfigExecutor
+        return Promise.resolve();
+    }
 }

--- a/services/init_service/projectBuilder.ts
+++ b/services/init_service/projectBuilder.ts
@@ -1,5 +1,53 @@
+import { ActivityConfig, ConfigTemplate } from "@/services/database_service/databaseServiceTypes";
+import { ProjectBuilderParams, ProjectBuildData } from "./projectInitTypes";
 
-
+/**
+ * ProjectBuilder aggregates all data required for project initialization.
+ * It follows a simple builder pattern with chainable setters.
+ */
 export class ProjectBuilder {
+    private data: ProjectBuildData;
 
+    constructor(params: ProjectBuilderParams) {
+        this.data = { ...params };
+    }
+
+    /**
+     * Attach ConfigTemplate selected for this project.
+     */
+    setTemplate(template: ConfigTemplate): this {
+        this.data.template = template;
+        return this;
+    }
+
+    /**
+     * Store user biometrics that will be used for profile creation.
+     */
+    setBiometrics(biometrics: Record<string, string | number>): this {
+        this.data.biometrics = biometrics;
+        return this;
+    }
+
+    /**
+     * Optional fitness goal for the workout plan.
+     */
+    setGoal(goal: string): this {
+        this.data.goal = goal;
+        return this;
+    }
+
+    /**
+     * Attach activity configs to be used during workout plan generation.
+     */
+    setActivities(activities: ActivityConfig[]): this {
+        this.data.activities = activities;
+        return this;
+    }
+
+    /**
+     * Finalize builder and return collected data.
+     */
+    build(): ProjectBuildData {
+        return this.data;
+    }
 }

--- a/services/init_service/projectInitTypes.ts
+++ b/services/init_service/projectInitTypes.ts
@@ -1,0 +1,20 @@
+export interface ProjectBuilderParams {
+    userId: string;
+    title: string;
+    description: string;
+}
+
+import { ConfigTemplate, ActivityConfig } from "@/services/database_service/databaseServiceTypes";
+
+export interface ProjectBuildData extends ProjectBuilderParams {
+    template?: ConfigTemplate;
+    biometrics?: Record<string, string | number>;
+    goal?: string;
+    activities?: ActivityConfig[];
+}
+
+export interface InitResult {
+    projectId: string;
+    profileId?: string;
+    // Additional fields may be added later
+}


### PR DESCRIPTION
## Summary
- flesh out ProjectBuilder with chainable methods
- implement InitProjectService with placeholders for AI modules
- define basic types for initialization
- add tests for init service

## Testing
- `npm run test-init`

------
https://chatgpt.com/codex/tasks/task_e_68694f0a54f88329899223c50c70c4d3